### PR TITLE
Possible fix for SwiftUI timing warnings

### DIFF
--- a/Sources/Combiner/Combiner+SwiftUI.swift
+++ b/Sources/Combiner/Combiner+SwiftUI.swift
@@ -27,7 +27,9 @@ extension Combiner {
         return Binding(
             get: { closure(self.currentState) },
             set: { [weak self] (value: U) in
-                self?.action.send(action(value))
+                DispatchQueue.main.async {
+                    self?.action.send(action(value))
+                }
             }
         )
     }


### PR DESCRIPTION
When binding is used to control SwiftUI sheet presentation, delaying the setter's publish action resolves this SwiftUI warning that may occur:

> Publishing changes from within view updates is not allowed, this will cause undefined behavior.

Observed on iOS 16 with Xcode 14.0.1

This issue has been encountered by others in the same situation. Please see:
https://developer.apple.com/forums/thread/711899
https://developer.apple.com/forums/thread/711899?page=2
