### PR TITLE
Always queue state updates on the main thread.

### DIFF
--- a/Sources/Combiner/Combiner.swift
+++ b/Sources/Combiner/Combiner.swift
@@ -95,11 +95,7 @@ extension Combiner {
                 self.hasInitialized = true
             }
 
-            if Thread.isMainThread && hasInitialized {
-                update()
-            } else {
-                DispatchQueue.main.async(execute: update)
-            }
+            DispatchQueue.main.async(execute: update)
         }
     }
 


### PR DESCRIPTION
## DESCRIPTION
This change makes it so that we never immediately publish state changes when the state changes.  The motivation for this is to avoid making changes to the state while the view is rendering.  I've observed issues in a project (NatureDose) where Xcode calls out this behavior as an error and state updates don't actually happen as expected because they're published while the view is still rendering.  This change avoids that possibility by making sure that any changes to the current state are queued and won't execute until the next cycle of the event loop on the main thread.

## AUTHOR
This PR is made on Melville Stanley <mel.stanley@gmail.com>'s behalf, who doesn't have write access to this repo


