### PR TITLE
SwiftUI Binding Cache

### DIFF
--- a/Sources/Combiner/Combiner+SwiftUI.swift
+++ b/Sources/Combiner/Combiner+SwiftUI.swift
@@ -27,9 +27,7 @@ extension Combiner {
         return Binding(
             get: { closure(self.currentState) },
             set: { [weak self] (value: U) in
-                DispatchQueue.main.async {
-                    self?.action.send(action(value))
-                }
+                self?.action.send(action(value))
             }
         )
     }


### PR DESCRIPTION
## DESCRIPTION

SwiftUI bindings built using `Combiner.State` as backing storage often don't update fast enough for SwiftUI, due to the full `action` + `mutation` cycle required for writes to `State` to take effect.  This causes some SwiftUI elements to behave abnormally, such as `TextEditor(text: Binding<String>)`, which seem to require instantaneous  updates to the bound value.

This PR updates `binding(action:getter:)` to return a locally cached value immediately to SwiftUI, circumventing the issue described above.  This "cache" is roughly analogous to  the high-speed memory buffer on a slower spinning HDD storage
